### PR TITLE
Improve security: SSH can only be accessed by lan

### DIFF
--- a/.github/workflows/NanoPi-R2S RK3328 OpenWrt 19.07 Build.yml
+++ b/.github/workflows/NanoPi-R2S RK3328 OpenWrt 19.07 Build.yml
@@ -125,6 +125,7 @@ jobs:
           sed -i '/Load Average/i\\t\t<tr><td width="33%"><%:CPU Temperature%></td><td><%=luci.sys.exec("cut -c1-2 /sys/class/thermal/thermal_zone0/temp")%></td></tr>' friendlywrt/feeds/luci/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
           sed -i 's/pcdata(boardinfo.system or "?")/"ARMv8"/' friendlywrt/feeds/luci/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
           sed -i "/redirect_https/d" friendlywrt/package/network/services/uhttpd/files/uhttpd.config
+          echo "        option Interface 'lan'" >> friendlywrt/package/network/services/dropbear/files/dropbear.config
 
       - name: Custom Configure Files
         run: |


### PR DESCRIPTION
默认只允许lan访问ssh，以避免设置为DMZ时被攻击。